### PR TITLE
Fix typo in sign-in error message

### DIFF
--- a/backend/routes/sign-in.js
+++ b/backend/routes/sign-in.js
@@ -53,7 +53,7 @@ const sing_In=module.exports.signIn = getInfo => {
             )
             .then(compareResult => {
                 // Compare failed
-                if (compareResult === false) throw new Error('Incorroct password', 404);
+                if (compareResult === false) throw new Error('Incorrect password', 404);
                
 
 


### PR DESCRIPTION
## Summary
- correct spelling of "Incorrect password" in sign-in route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841596dcac4832e932319ffa6fdc098